### PR TITLE
Bugfix for searching by hash when file size is greater than a 32-bit integer.

### DIFF
--- a/pythonopensubtitles/opensubtitles.py
+++ b/pythonopensubtitles/opensubtitles.py
@@ -1,4 +1,4 @@
-from xmlrpclib import ServerProxy
+from xmlrpclib import ServerProxy, Marshaller
 
 from settings import Settings
 
@@ -13,6 +13,7 @@ class OpenSubtitles(object):
     def __init__(self, language=None):
         self.xmlrpc = ServerProxy(Settings.OPENSUBTITLES_SERVER,
                                   allow_none=True)
+        Marshaller.dispatch[type(0L)] = lambda _, v, w: w("<value><i8>%d</i8></value>" % v)
         self.language = language or Settings.LANGUAGE
         self.token = None
 

--- a/pythonopensubtitles/utils.py
+++ b/pythonopensubtitles/utils.py
@@ -20,7 +20,7 @@ def get_md5(file_path):
 class File(object):
     def __init__(self, path):
         self.path = path
-        self.size = os.path.getsize(path)
+        self.size = long(os.path.getsize(path))
 
     def get_hash(self):
         '''Original from: http://goo.gl/qqfM0


### PR DESCRIPTION
First, xmlrpc was configured to properly handle long types (see
http://stackoverflow.com/questions/18533309/xmlrpc-response-datatype-long-possible).  Also, in
utils.File, the size attribute is now stored as a long.  Python actually unified int and long
awhile back (see PEP 237), so os.path.getsize actually returns an int regardless if it is larger
than a 32-bit number.  This commit casts the value returned by os.path.getsize to a long.  This
is nothing more than a quick fix to this particular bug.  It is possible that there could be more
bugs relating to integer size when using the xmlrpclib package.
