### PR TITLE
fix pip freeze svn requirements error

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ python-opensubtitles
 Simple module to access to the [OpenSubtitles.org](http://opensubtitles.org)
 subtitles database. This class is a wrapper to the common methods at OS.
 
+# Installing Notes
+
+If you are installing this using `pip`, please use the following format:
+`pip install -e git+<github repo url>#egg=python-opensubtitles`
+
 # Configuring the test environment
 
 Before start to running the test (if you are only reading the documentation,

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ subtitles database. This class is a wrapper to the common methods at OS.
 # Installing Notes
 
 If you are installing this using `pip`, please use the following format:
-`pip install -e git+<github repo url>#egg=python-opensubtitles`
+`pip install -e git+http://github.com/agonzalezro/python-opensubtitles#egg=python-opensubtitles`
 
 # Configuring the test environment
 

--- a/python_opensubtitles.egg-info/SOURCES.txt
+++ b/python_opensubtitles.egg-info/SOURCES.txt
@@ -7,3 +7,6 @@ python_opensubtitles.egg-info/entry_points.txt
 python_opensubtitles.egg-info/not-zip-safe
 python_opensubtitles.egg-info/top_level.txt
 pythonopensubtitles/__init__.py
+pythonopensubtitles/opensubtitles.py
+pythonopensubtitles/settings.py
+pythonopensubtitles/utils.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-Django==1.8.2
--e git+https://github.com/coolharsh55/python-opensubtitles@f37074796ee72c7efe1aa3ec2d534b4299b8fd88#egg=python_opensubtitles-master
-wheel==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Django==1.8.2
+-e git+https://github.com/coolharsh55/python-opensubtitles@f37074796ee72c7efe1aa3ec2d534b4299b8fd88#egg=python_opensubtitles-master
+wheel==0.24.0

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,2 @@
 [egg_info]
 tag_build = dev
-tag_svn_revision = true


### PR DESCRIPTION
On successful install by `pip install git+<url>`, the *freezed* (`pip freeze`) list
specified an error titled `FIXME: Could not find a version that satisfies
the requirement`. This was due to the `svg = true` configuration in `setup.cfg`
Removing that same removes the error. To create a successful install
and enable it to be ported via **requirements.txt**, use the `-e` option of
`pip`. Attached example requirements.txt.