### PR TITLE
opensubtitles.py implement subtitles downloading

### DIFF
--- a/pythonopensubtitles/opensubtitles.py
+++ b/pythonopensubtitles/opensubtitles.py
@@ -1,7 +1,6 @@
-import base64
+from .utils import decompress
 import os.path
 import sys
-import zlib
 
 try:                    #Python 2
     from xmlrpclib import ServerProxy
@@ -9,36 +8,6 @@ try:                    #Python 2
 except ImportError:     #Python 3
     from xmlrpc.client import ServerProxy
     from .settings import Settings
-
-
-def decompress_utf_8(data):
-    """
-    Convert a base64-compressed subtitles file with utf-8 encoding
-    back to a string.
-    """
-    decompressed = None
-    try:
-        decompressed = zlib.decompress(base64.b64decode(data),
-                                       16 + zlib.MAX_WBITS).decode('utf-8')
-    except UnicodeDecodeError as e:
-        print(e)
-
-    return decompressed
-
-
-def decompress_latin(data):
-    """
-    Convert a base64-compressed subtitles file with latin-1 encoding
-    back to a string.
-    """
-    decompressed = None
-    try:
-        decompressed = zlib.decompress(base64.b64decode(data),
-                                       16 + zlib.MAX_WBITS).decode('latin1')
-    except UnicodeDecodeError as e:
-        print(e)
-
-    return decompressed
 
 
 class OpenSubtitles(object):
@@ -179,8 +148,8 @@ class OpenSubtitles(object):
         for item in encoded_data:
             subfile_id = item['idsubtitlefile']
 
-            decoded_data = (decompress_utf_8(item['data'])
-                            or decompress_latin(item['data']))
+            decoded_data = (decompress(item['data'], 'utf-8')
+                            or decompress(item['data'], 'latin1'))
 
             if not decoded_data:
                 print("An error occurred while decoding subtitle "

--- a/pythonopensubtitles/utils.py
+++ b/pythonopensubtitles/utils.py
@@ -5,6 +5,21 @@ import zlib
 import base64
 
 
+def decompress(data, encoding):
+    """
+    Convert a base64-compressed subtitles file back to a string.
+
+    :param data: the compressed data
+    :param encoding: the encoding of the original file (e.g. utf-8, latin1)
+    """
+    try:
+        return zlib.decompress(base64.b64decode(data),
+                               16 + zlib.MAX_WBITS).decode(encoding)
+    except UnicodeDecodeError as e:
+        print(e)
+        return
+
+
 def get_gzip_base64_encoded(file_path):
     handler = open(file_path, mode='rb').read()
     return base64.encodestring(zlib.compress(handler))


### PR DESCRIPTION
I implemented `download_subtitles`, the one function I was missing the most! (see #13)

I only noticed half-way through that the module is (possibly? not quite sure) also supposed to support Python2... though maybe any Python2 code in there only exists for history reason, because the code was originally written in 2 (?).

I only do Python3 in any case – don't know any 2, don't use any libraries for which I'd need to know it etc. Hopefully this PR can still be accepted (I could possibly make note of this in the README?) until someone adapts it to also support Python2, or Python2 support is phased out/dropped entirely.