### PR TITLE
SyntaxError in line 156 'file=sys.stderr' in opensubtitles.py fix

### DIFF
--- a/pythonopensubtitles/opensubtitles.py
+++ b/pythonopensubtitles/opensubtitles.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from .utils import decompress
 import os
 import os.path


### PR DESCRIPTION
Code is now compatible with both Python 2.x as well as Python 3.x