### PR TITLE
Fix report_wrong_movie_hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ pip install -e git+https://github.com/agonzalezro/python-opensubtitles#egg=pytho
 ## Configuring the test environment
 
 Before you start running tests (if you are only reading the documentation, of course, you don't need to do it :D), you must provide a correct video path and subtitle path.
-
     >>> from os import path
     >>> class Test(object):
     ...     username = 'doctest'
@@ -149,7 +148,7 @@ optional.
 
 If you find that the movie hash of subtitle file data is incorrect or is for some other release or version use this method to report it.Once enough people report, hash will be deleted from opensubtitles.org.
 
-    >>> data = ost.report_wrong_movie_hash([id_sub_movie_file])
+    >>> ost.report_wrong_movie_hash(id_sub_movie_file)
     True
 
 

--- a/pythonopensubtitles/opensubtitles.py
+++ b/pythonopensubtitles/opensubtitles.py
@@ -204,7 +204,7 @@ class OpenSubtitles(object):
         :param id_sub_movie_file: identifier for subtitle file and video file combination.
         '''
         self.data = self.xmlrpc.ReportWrongMovieHash(self.token,id_sub_movie_file)
-        return '200' in self._get_from_data_or_none('status')
+        return '200' in self.data.get('status')
 
     def get_subtitle_languages(self,language='en'):
         '''Returns list of supported subtitle languages in specified langauge; default is english.


### PR DESCRIPTION
Status code should be retrieved using dictionary get() method
not _get_from_data_or_none().
report_wrong_movie_hash should be given a single string value not
a list in doctest and output should not be stored in variable.