### PR TITLE
Implement optional capability to detect subtitle encoding

### DIFF
--- a/pythonopensubtitles/opensubtitles.py
+++ b/pythonopensubtitles/opensubtitles.py
@@ -189,8 +189,7 @@ class OpenSubtitles(object):
         for item in encoded_data:
             subfile_id = item['idsubtitlefile']
 
-            decoded_data = (decompress(item['data'], 'utf-8')
-                            or decompress(item['data'], 'latin1'))
+            decoded_data = decompress(item['data'])
 
             if not decoded_data:
                 print("An error occurred while decoding subtitle "

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from platform import python_version_tuple
 import sys, os
 
 version = '0.2'
@@ -15,4 +16,10 @@ setup(
     packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
     include_package_data=True,
     zip_safe=False,
+    extras_require={
+        'Support for encoding detection on downloaded subtitle':
+            [
+                'charset_normalizer' if int(python_version_tuple()[0]) >= 3 else 'chardet'
+            ],
+    }
 )


### PR DESCRIPTION
Optional capability to detect subtitle encoding
------------

This package try initialy to decode decompressed subtitle with UTF-8 or latin-1 if UTF-8 failed. Assuming every subtitle are encoded with UTF-8 or latin-1 is wrong. 

I'm opening this PR in order to propose a way to remplacing default behaviour of decoding decompressed subtitle.

This change does not break backward compatibility and this feature is set as optional for now.

Three package are compatible : 
  - chardet (py < 3.4)
  - charset-normalizer (py > 3.4)
  - cchardet (not used by default)

This is going to help when downloading arabic, russian, hebrew, etc.. Encoded with cp1256, cp1251, cp1255, etc..

:tada: 