### PR TITLE
added encoding to prevent Unicode Errors when downloading subtitle.

### DIFF
--- a/pythonopensubtitles/opensubtitles.py
+++ b/pythonopensubtitles/opensubtitles.py
@@ -207,7 +207,7 @@ class OpenSubtitles(object):
                 fpath = os.path.join(directory, fname)
 
                 try:
-                    with open(fpath, 'w') as f:
+                    with open(fpath, 'w', encoding="utf-8") as f:
                         f.write(decoded_data)
                     successful[subfile_id] = fpath
                 except IOError as e:


### PR DESCRIPTION
Dear Alexandre, 
I added UTF8 encoding when downloading the subtitle, as I was always running into UniCode errors when downloading subtitles. 
Best wishes
pirwlan

PS: This is my first contribution on github, sorry if I did anything wrong. 