### PR TITLE
Fix base64 deprecated function

### DIFF
--- a/pythonopensubtitles/utils.py
+++ b/pythonopensubtitles/utils.py
@@ -47,8 +47,8 @@ def decompress(data, enable_encoding_guessing=True, encoding='utf-8'):
 
 
 def get_gzip_base64_encoded(file_path):
-    handler = open(file_path, mode='rb').read()
-    return base64.encodestring(zlib.compress(handler))
+    with open(file_path, mode="rb") as file:
+        return base64.encodebytes(zlib.compress(file.read())).decode("utf-8")
 
 
 def get_md5(file_path):

--- a/pythonopensubtitles/utils.py
+++ b/pythonopensubtitles/utils.py
@@ -1,5 +1,6 @@
 import struct
 import os
+import sys
 import hashlib
 import zlib
 import base64
@@ -48,7 +49,11 @@ def decompress(data, enable_encoding_guessing=True, encoding='utf-8'):
 
 def get_gzip_base64_encoded(file_path):
     with open(file_path, mode="rb") as file:
-        return base64.encodebytes(zlib.compress(file.read())).decode("utf-8")
+        compressed_data = zlib.compress(file.read())
+        if sys.version_info[0] >= 3 and sys.version_info[1] >= 1:
+            return base64.encodebytes(compressed_data).decode("utf-8")
+        else:
+            return base64.encodestring(compressed_data).decode("utf-8")
 
 
 def get_md5(file_path):


### PR DESCRIPTION
Hi,

Happy new year  🎉

This pull request fixes a deprecated function and adds backward compatibility. 
I tested the code with python 2.7, python 3.0, python 3.2 and python 3.9.9 however I was not able to test with python 3.1 because it doesn't compile on `mac os` and `ubuntu`. 